### PR TITLE
[APERTURE-959] Fix Nullable Datetime64

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,7 @@
 name: Unit Test
 on:
   pull_request:
-    types: [ opened, synchronize, ready_for_review ]
+    types: [opened, synchronize, ready_for_review]
 
 jobs:
   test:
@@ -11,11 +11,13 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
       - name: Start up docker compose
         run: docker compose -f docker-compose.yaml up -d --remove-orphans
       - name: Run Tests
-        run: go test -v -race -p=6 -cpu=1,4 ./...
+        run: go test -v -race -p=6 -cpu=1 ./...
+      - name: Run Tests
+        run: go test -v -race -p=6 -cpu=4 ./...
       - name: Stop containers
         if: always()
         run: docker compose -f docker-compose.yaml down

--- a/ch/chschema/column_nullable.go
+++ b/ch/chschema/column_nullable.go
@@ -12,10 +12,10 @@ type NullableColumn struct {
 	nullable reflect.Value // reflect.Slice
 }
 
-func NewNullableColumnFunc(fn NewColumnFunc) NewColumnFunc {
+func NewNullableColumnFunc(col Columnar) NewColumnFunc {
 	return func() Columnar {
 		return &NullableColumn{
-			Values: fn(),
+			Values: col,
 		}
 	}
 }

--- a/ch/chschema/types.go
+++ b/ch/chschema/types.go
@@ -197,7 +197,7 @@ func ColumnFactory(chType string, typ reflect.Type) NewColumnFunc {
 		if typ != nil {
 			typ = typ.Elem()
 		}
-		return NewNullableColumnFunc(ColumnFactory(chType, typ))
+		return NewNullableColumnFunc(NewColumn(chType, typ))
 	}
 
 	if chType := chSimpleAggFunc(chType); chType != "" {
@@ -224,7 +224,7 @@ func ColumnFactory(chType string, typ reflect.Type) NewColumnFunc {
 		if typ.Elem().Kind() == reflect.Struct {
 			return NewJSONColumn
 		}
-		return NewNullableColumnFunc(ColumnFactory(chNullableType(chType), typ.Elem()))
+		return NewNullableColumnFunc(NewColumn(chNullableType(chType), typ.Elem()))
 	case reflect.Slice:
 		switch elem := typ.Elem(); elem.Kind() {
 		case reflect.Ptr:

--- a/ch/db_test.go
+++ b/ch/db_test.go
@@ -114,7 +114,7 @@ func TestDSNSetting(t *testing.T) {
 	}
 }
 
-func TestNullable(t *testing.T) {
+func TestNullableString(t *testing.T) {
 	ctx := context.Background()
 
 	db := chDB()

--- a/ch/db_test.go
+++ b/ch/db_test.go
@@ -267,8 +267,8 @@ func TestScanArrayUint8(t *testing.T) {
 
 func TestDateTime64(t *testing.T) {
 	type Model struct {
-		Time       time.Time `ch:"type:DateTime64(9)"`
-		TimeWithTZ time.Time `ch:"type:DateTime64(9, 'UTC')"`
+		TimeNanoPrec       time.Time `ch:"type:DateTime64(9)"`
+		TimeNanoPrecWithTZ time.Time `ch:"type:DateTime64(9, 'UTC')"`
 	}
 
 	ctx := context.Background()
@@ -280,8 +280,8 @@ func TestDateTime64(t *testing.T) {
 	require.NoError(t, err)
 
 	in := &Model{
-		Time:       time.Unix(0, 12345678912345),
-		TimeWithTZ: time.Unix(0, 12345678912345).In(time.UTC),
+		TimeNanoPrec:       time.Unix(0, 12345678912345),
+		TimeNanoPrecWithTZ: time.Unix(0, 12345678912345).In(time.UTC),
 	}
 	_, err = db.NewInsert().Model(in).Exec(ctx)
 	require.NoError(t, err)
@@ -289,8 +289,8 @@ func TestDateTime64(t *testing.T) {
 	out := new(Model)
 	err = db.NewSelect().Model(out).Scan(ctx)
 	require.NoError(t, err)
-	require.Equal(t, in.Time.UnixNano(), out.Time.UnixNano())
-	require.Equal(t, in.TimeWithTZ.UnixNano(), out.TimeWithTZ.UnixNano())
+	require.Equal(t, in.TimeNanoPrec.UnixNano(), out.TimeNanoPrec.UnixNano())
+	require.Equal(t, in.TimeNanoPrecWithTZ.UnixNano(), out.TimeNanoPrecWithTZ.UnixNano())
 }
 
 func TestInvalidType(t *testing.T) {

--- a/ch/db_test.go
+++ b/ch/db_test.go
@@ -267,6 +267,9 @@ func TestScanArrayUint8(t *testing.T) {
 
 func TestDateTime64(t *testing.T) {
 	type Model struct {
+		TimeSecPrec       time.Time `ch:"type:DateTime64(0)"`
+		TimeSecPrecWithTZ time.Time `ch:"type:DateTime64(0, 'UTC')"`
+
 		TimeNanoPrec       time.Time `ch:"type:DateTime64(9)"`
 		TimeNanoPrecWithTZ time.Time `ch:"type:DateTime64(9, 'UTC')"`
 	}
@@ -280,6 +283,9 @@ func TestDateTime64(t *testing.T) {
 	require.NoError(t, err)
 
 	in := &Model{
+		TimeSecPrec:       time.Unix(0, 12345678912345),
+		TimeSecPrecWithTZ: time.Unix(0, 12345678912345).In(time.UTC),
+
 		TimeNanoPrec:       time.Unix(0, 12345678912345),
 		TimeNanoPrecWithTZ: time.Unix(0, 12345678912345).In(time.UTC),
 	}
@@ -289,6 +295,10 @@ func TestDateTime64(t *testing.T) {
 	out := new(Model)
 	err = db.NewSelect().Model(out).Scan(ctx)
 	require.NoError(t, err)
+
+	require.Equal(t, in.TimeSecPrec.Truncate(time.Second).UnixNano(), out.TimeSecPrec.UnixNano())
+	require.Equal(t, in.TimeSecPrecWithTZ.Truncate(time.Second).UnixNano(), out.TimeSecPrecWithTZ.UnixNano())
+
 	require.Equal(t, in.TimeNanoPrec.UnixNano(), out.TimeNanoPrec.UnixNano())
 	require.Equal(t, in.TimeNanoPrecWithTZ.UnixNano(), out.TimeNanoPrecWithTZ.UnixNano())
 }

--- a/ch/db_test.go
+++ b/ch/db_test.go
@@ -303,6 +303,71 @@ func TestDateTime64(t *testing.T) {
 	require.Equal(t, in.TimeNanoPrecWithTZ.UnixNano(), out.TimeNanoPrecWithTZ.UnixNano())
 }
 
+func TestNullableDateTime64(t *testing.T) {
+	type Model struct {
+		TimeNull       *time.Time `ch:"type:Nullable(DateTime64(0))"`
+		TimeNullWithTZ *time.Time `ch:"type:Nullable(DateTime64(0, 'UTC'))"`
+
+		TimeSecPrec       *time.Time `ch:"type:Nullable(DateTime64(0))"`
+		TimeSecPrecWithTZ *time.Time `ch:"type:Nullable(DateTime64(0, 'UTC'))"`
+
+		TimeMilliPrec       *time.Time `ch:"type:Nullable(DateTime64(3))"`
+		TimeMilliPrecWithTZ *time.Time `ch:"type:Nullable(DateTime64(3, 'UTC'))"`
+
+		TimeNanoPrec       *time.Time `ch:"type:Nullable(DateTime64(9))"`
+		TimeNanoPrecWithTZ *time.Time `ch:"type:Nullable(DateTime64(9, 'UTC'))"`
+	}
+
+	ctx := context.Background()
+
+	db := chDB()
+	defer db.Close()
+
+	err := db.ResetModel(ctx, (*Model)(nil))
+	require.NoError(t, err)
+
+	timeSecPrec := time.Unix(0, 12345678912345)
+	timeSecPrecWithTZ := time.Unix(0, 12345678912345).In(time.UTC)
+
+	timeMilliPrec := time.Unix(0, 12345678912345)
+	timeMilliPrecWithTZ := time.Unix(0, 12345678912345).In(time.UTC)
+
+	timeNanoPrec := time.Unix(0, 12345678912345)
+	timeNanoPrecWithTZ := time.Unix(0, 12345678912345).In(time.UTC)
+
+	in := &Model{
+		TimeNull:       nil,
+		TimeNullWithTZ: nil,
+
+		TimeSecPrec:       &timeSecPrec,
+		TimeSecPrecWithTZ: &timeSecPrecWithTZ,
+
+		TimeMilliPrec:       &timeMilliPrec,
+		TimeMilliPrecWithTZ: &timeMilliPrecWithTZ,
+
+		TimeNanoPrec:       &timeNanoPrec,
+		TimeNanoPrecWithTZ: &timeNanoPrecWithTZ,
+	}
+	_, err = db.NewInsert().Model(in).Exec(ctx)
+	require.NoError(t, err)
+
+	out := new(Model)
+	err = db.NewSelect().Model(out).Scan(ctx)
+	require.NoError(t, err)
+
+	require.Nil(t, out.TimeNull)
+	require.Nil(t, out.TimeNullWithTZ)
+
+	require.Equal(t, timeSecPrec.Truncate(time.Second).UnixNano(), out.TimeSecPrec.UnixNano())
+	require.Equal(t, timeSecPrecWithTZ.Truncate(time.Second).UnixNano(), out.TimeSecPrecWithTZ.UnixNano())
+
+	require.Equal(t, timeMilliPrec.Truncate(time.Millisecond).UnixNano(), out.TimeMilliPrec.UnixNano())
+	require.Equal(t, timeMilliPrecWithTZ.Truncate(time.Millisecond).UnixNano(), out.TimeMilliPrecWithTZ.UnixNano())
+
+	require.Equal(t, timeNanoPrec.UnixNano(), out.TimeNanoPrec.UnixNano())
+	require.Equal(t, timeNanoPrecWithTZ.UnixNano(), out.TimeNanoPrecWithTZ.UnixNano())
+}
+
 func TestInvalidType(t *testing.T) {
 	t.Skip()
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   clickhouse:
@@ -7,4 +7,5 @@ services:
       - CLICKHOUSE_ADMIN_USER=clickhouse
       - CLICKHOUSE_ADMIN_PASSWORD=secret
     ports:
-      - '9000:9000'
+      - "9000:9000"
+      - "8123:8123"


### PR DESCRIPTION
The issue is like this:
1. `NewColumn` has a two-step process: define the column type and init - https://github.com/glassdomeinc/clicky/blob/release/v0.3.3/ch/chschema/types.go#L72
2. Precision for `NewDateTime64Column` is set init, not the creation - https://github.com/glassdomeinc/clicky/blob/release/v0.3.3/ch/chschema/column.go#L295-L302
3. `NewNullableColumnFunc` returns the closure that captures the `NewColumnFunc` to create `NewDateTime64Column`, which will never get a chance to be initialized.

Resolve the issue by making the closure to keep the initialized `NewDateTime64Column` so it can use the precision for read/write.

Also, update the test workflow to run the tests sequentially because the tests are not fully isolated.