### PR TITLE
[APERTURE-959] Lazy creation & initialization

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,9 +15,7 @@ jobs:
       - name: Start up docker compose
         run: docker compose -f docker-compose.yaml up -d --remove-orphans
       - name: Run Tests
-        run: go test -v -race -p=6 -cpu=1 ./...
-      - name: Run Tests
-        run: go test -v -race -p=6 -cpu=4 ./...
+        run: go test -v -race -p=6 -cpu=1,4 ./...
       - name: Stop containers
         if: always()
         run: docker compose -f docker-compose.yaml down

--- a/ch/chschema/column_nullable.go
+++ b/ch/chschema/column_nullable.go
@@ -12,8 +12,12 @@ type NullableColumn struct {
 	nullable reflect.Value // reflect.Slice
 }
 
-func NewNullableColumnFunc(col Columnar) NewColumnFunc {
+func NewNullableColumnFunc(chType string, typ reflect.Type) NewColumnFunc {
+	fn := ColumnFactory(chType, typ)
+
 	return func() Columnar {
+		col := fn()
+		col.Init(chType)
 		return &NullableColumn{
 			Values: col,
 		}

--- a/ch/chschema/types.go
+++ b/ch/chschema/types.go
@@ -197,7 +197,7 @@ func ColumnFactory(chType string, typ reflect.Type) NewColumnFunc {
 		if typ != nil {
 			typ = typ.Elem()
 		}
-		return NewNullableColumnFunc(NewColumn(chType, typ))
+		return NewNullableColumnFunc(chType, typ)
 	}
 
 	if chType := chSimpleAggFunc(chType); chType != "" {
@@ -224,7 +224,7 @@ func ColumnFactory(chType string, typ reflect.Type) NewColumnFunc {
 		if typ.Elem().Kind() == reflect.Struct {
 			return NewJSONColumn
 		}
-		return NewNullableColumnFunc(NewColumn(chNullableType(chType), typ.Elem()))
+		return NewNullableColumnFunc(chNullableType(chType), typ.Elem())
 	case reflect.Slice:
 		switch elem := typ.Elem(); elem.Kind() {
 		case reflect.Ptr:


### PR DESCRIPTION
I was getting the below error only when running the tests in parallel, so I thought the issue happened because of the lack of isolation for tests in this repo.
`--- FAIL: TestNullableString (0.01s)
panic: column=created_at does not have expected number of rows: got 3, wanted 6 [recovered]`

But I found the same issue while merging the driver to the workspace, so it seems like an issue with the creation & initialization sequence. It was doing lazy creation for DateTime64 inside (no initialization after that tho), but now it creates and initializes DateTime64 at the beginning.

After updating the sequence to use lazy creation & initialization, it passed all the Clickhouse tests in the workspace, and the tests in this repo with the original test config. So rollback the test workflow.