### PR TITLE
fix: schema explicit bool values

### DIFF
--- a/ch/chschema/append.go
+++ b/ch/chschema/append.go
@@ -66,11 +66,10 @@ func AppendNull(b []byte) []byte {
 }
 
 func AppendBool(dst []byte, v bool) []byte {
-	var c byte
 	if v {
-		c = 1
+		return append(dst, "true"...)
 	}
-	return append(dst, c)
+	return append(dst, "false"...)
 }
 
 func AppendFloat(dst []byte, v float64) []byte {


### PR DESCRIPTION
using 0 byte for false value incorrectly formats query `boolean = ?` to `boolean = `.